### PR TITLE
Remove old comment

### DIFF
--- a/Tests/muterTests/subCommandsSpec.swift
+++ b/Tests/muterTests/subCommandsSpec.swift
@@ -128,7 +128,6 @@ class CLISubcommandSpec: QuickSpec {
                         muterCore.run(with: configuration, fileManager: fileManager, in: "/some/test", performMutationTesting: { (currentDirectoryPath, actualConfiguration) in
                             expect(currentDirectoryPath).to(equal("/this/is/a/fake/temp/test"))
                             expect(actualConfiguration).to(equal(configuration))
-                            //                            expect(fileManager.methodCalls).to(equal(["url(for:in:appropriateFor:create:)"]))
                             expect(fileManager.searchPathDirectories).to(equal([.itemReplacementDirectory]))
                             expect(fileManager.domains).to(equal([.userDomainMask]))
                             expect(fileManager.paths).to(equal(["/some/test"]))


### PR DESCRIPTION
I think this just got in by mistake, but maybe we had wanted to make an extra test to make sure everything got called in the right order?