### PR TITLE
Ignore mutations in declarations

### DIFF
--- a/Sources/muterCore/MutationOperators/NegateConditionalsOperator.swift
+++ b/Sources/muterCore/MutationOperators/NegateConditionalsOperator.swift
@@ -18,6 +18,10 @@ enum NegateConditionalsOperator {
                 return
             }
 
+            guard token.parent?.isDecl == false else {
+                return
+            }
+
             positionsOfToken.append(token.position)
         }
     }

--- a/Tests/fixtures/sampleForDiscoveringMutations.swift
+++ b/Tests/fixtures/sampleForDiscoveringMutations.swift
@@ -3,4 +3,7 @@ struct Example2 {
         let b = a != a
         return b == a ? "equal" : "not equal"
     }
+    func < (lhs: String, rhs: String) -> Bool {
+        return false
+    }
 }

--- a/Tests/mutationDiscoverySpec.swift
+++ b/Tests/mutationDiscoverySpec.swift
@@ -44,6 +44,15 @@ class MutationDiscoverySpec: QuickSpec {
                 expect(operatorsForNonSwiftCode.count).to(equal(0))
                 expect(operators.count).to(equal(2))
             }
+
+            it("doesn't discover any mutation operators in function declarations") {
+                let operators = discoverMutationOperators(inFilesAt: [
+                    "\(self.fixturesDirectory)/sampleForDiscoveringMutations.swift",
+                ])
+                let functionOperator = operators.first(where: { $0.position.line == 7 && $0.position.column == 10 })
+
+                expect(functionOperator).to(beNil())
+            }
         }
     }
 }


### PR DESCRIPTION
[fixes #11]

- If a Negate Conditional Operator mutation is within a declaration, it
  is ignored.
- Add a `<` function to `sampleForDiscoveringMutations.swift`