### PR TITLE
Fix File Operation Specs for non-english-US locales

### DIFF
--- a/Tests/fileOperationsSpec.swift
+++ b/Tests/fileOperationsSpec.swift
@@ -19,7 +19,7 @@ class FileOperationSpec: QuickSpec {
                 
                 let loggingDirectory = createLoggingDirectory(in: "~/some/path",
                                                               fileManager: fileManagerSpy,
-                                                              locale: Locale(identifier: "enUS"),
+                                                              locale: Locale(identifier: "en_US"),
                                                               timestamp:  { timestamp.date! })
 
                 expect(loggingDirectory).to(equal("~/some/path/muter_logs/May 10, 2019 at 2:42 AM"))


### PR DESCRIPTION
Currently, mutter won't build since the locale is not correctly set up in tests. This will make mutter tests fail on the machines with the non-`en_US` locales