### PR TITLE
--output-xcode doesn't use temporary paths

### DIFF
--- a/AcceptanceTests/AcceptanceTests.swift
+++ b/AcceptanceTests/AcceptanceTests.swift
@@ -97,6 +97,13 @@ class AcceptanceTests: QuickSpec {
                     they("see their results in a format consumable by an Xcode build script") {
                         expect(self.numberOfXcodeFormattedMessages(in: output)).to(equal(1))
                     }
+                    
+                    they("see only one temporary path") {
+                        let numberOfTemporaryPaths = output.split(separator: "\n").count {
+                            $0.contains("/T/TemporaryItems/")
+                        }
+                        expect(numberOfTemporaryPaths) == 1
+                    }
                 }
                 
                 context("with --files-to-mutate as an argument") {

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/PerformMutationTesting.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/PerformMutationTesting.swift
@@ -69,10 +69,12 @@ private extension PerformMutationTesting {
                                                                       savingResultsIntoFileNamed: logFileName(for: mutationPoint))
 
             ioDelegate.restoreFile(at: mutationPoint.filePath, using: state.swapFilePathsByOriginalPath)
+
             
             let outcome = MutationTestOutcome(testSuiteOutcome: testSuiteOutcome,
                                               mutationPoint: mutationPoint,
-                                              operatorDescription: mutantDescription)
+                                              operatorDescription: mutantDescription,
+                                              originalProjectDirectoryUrl: state.projectDirectoryURL)
             outcomes.append(outcome)
             
             notificationCenter.post(name: .newMutationTestOutcomeAvailable,

--- a/Sources/muterCore/TestReporting/MutationTestOutcome.swift
+++ b/Sources/muterCore/TestReporting/MutationTestOutcome.swift
@@ -1,15 +1,28 @@
 import SwiftSyntax
+import Foundation
 
 public struct MutationTestOutcome: Equatable {
     let testSuiteOutcome: TestSuiteOutcome
     let mutationPoint: MutationPoint
     let operatorDescription: String
-
+    let originalProjectPath: String
+    
     public init(testSuiteOutcome: TestSuiteOutcome,
                 mutationPoint: MutationPoint,
-                operatorDescription: String) {
+                operatorDescription: String,
+                originalProjectDirectoryUrl: URL) {
         self.testSuiteOutcome = testSuiteOutcome
         self.mutationPoint = mutationPoint
         self.operatorDescription = operatorDescription
+        
+        let splitTempFilePath = mutationPoint.filePath.split(separator: "/")
+        let projectDirectoryName = originalProjectDirectoryUrl.lastPathComponent
+        let numberOfDirectoriesToDrop = splitTempFilePath.map(String.init).firstIndex(of: projectDirectoryName) ?? 0
+        let pathSuffix = splitTempFilePath.dropFirst(numberOfDirectoriesToDrop).joined(separator: "/")
+        
+        self.originalProjectPath = originalProjectDirectoryUrl
+            .deletingLastPathComponent()
+            .appendingPathComponent(pathSuffix, isDirectory: true)
+            .path
     }
 }

--- a/Sources/muterCore/TestReporting/MuterTestReport.swift
+++ b/Sources/muterCore/TestReporting/MuterTestReport.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftSyntax
 
 typealias FileName = String
-typealias FilePath = String
+public typealias FilePath = String
 
 public struct MuterTestReport {
     let globalMutationScore: Int

--- a/Sources/muterCore/TestReporting/Reporter.swift
+++ b/Sources/muterCore/TestReporting/Reporter.swift
@@ -79,7 +79,8 @@ private extension Reporter {
     
     private func outcomeIntoXcodeString(outcome: MutationTestOutcome)  -> String  {
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
-        return "\(outcome.mutationPoint.filePath):" +
+
+        return "\(outcome.originalProjectPath):" +
             "\(outcome.mutationPoint.position.line):\(outcome.mutationPoint.position.column): " +
             "warning: " +
         "Your test suite did not kill this mutant: \(outcome.operatorDescription)"

--- a/Sources/muterCore/version.swift
+++ b/Sources/muterCore/version.swift
@@ -1,1 +1,1 @@
-let version = "v11"
+let version = "v12-DEV"

--- a/Tests/Extensions/MutationTestOutcomeExtensions.swift
+++ b/Tests/Extensions/MutationTestOutcomeExtensions.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import muterCore
+
+public extension MutationTestOutcome {
+    init(testSuiteOutcome: TestSuiteOutcome,
+         mutationPoint: MutationPoint,
+         operatorDescription: String = "") {
+        self.init(testSuiteOutcome: testSuiteOutcome,
+                  mutationPoint: mutationPoint,
+                  operatorDescription: operatorDescription,
+                  originalProjectDirectoryUrl: URL(fileURLWithPath: ""))
+        
+    }
+}

--- a/Tests/TestReporting/MutationTestOutcomeSpec.swift
+++ b/Tests/TestReporting/MutationTestOutcomeSpec.swift
@@ -1,0 +1,56 @@
+import Quick
+import Nimble
+import Foundation
+@testable import muterCore
+
+class MutationTestOutcomeSpec: QuickSpec {
+    override func spec() {
+        describe("MutationTestOutcome") {
+            describe("how it converts paths") {
+                context("when the path of a file with a mutation point is deeply nested") {
+                    it("maps the paths") {
+                        let mutationPoint = MutationPoint(mutationOperatorId: .logicalOperator,
+                                                          filePath: "/var/tmp/nonsense/ProjectDirectory/Subdirectory/file.swift",
+                                                          position: .firstPosition)
+                        
+                        let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
+                                                          mutationPoint: mutationPoint,
+                                                          operatorDescription: "",
+                                                          originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Code/ProjectDirectory"))
+                        
+                        expect(outcome.originalProjectPath) == "/Users/user0/Code/ProjectDirectory/Subdirectory/file.swift"
+                    }
+                }
+                
+                context("when the path of a file with a mutation point is shallowly nested") {
+                    it("maps the paths") {
+                        let mutationPoint = MutationPoint(mutationOperatorId: .logicalOperator,
+                                                          filePath: "/tmp/ProjectDirectory/file.swift",
+                                                          position: .firstPosition)
+                        
+                        let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
+                                                          mutationPoint: mutationPoint,
+                                                          operatorDescription: "",
+                                                          originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Code/ProjectDirectory"))
+                        expect(outcome.originalProjectPath) == "/Users/user0/Code/ProjectDirectory/file.swift"
+                        
+                    }
+                }
+                
+                context("when the path of a file with a mutation point has spaces") {
+                    it("maps the paths") {
+                        let mutationPoint = MutationPoint(mutationOperatorId: .logicalOperator,
+                                                          filePath: "/tmp/Project Directory/file.swift",
+                                                          position: .firstPosition)
+                        
+                        let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
+                                                          mutationPoint: mutationPoint,
+                                                          operatorDescription: "",
+                                                          originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Project Directory"))
+                        expect(outcome.originalProjectPath) == "/Users/user0/Project Directory/file.swift"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/TestReporting/MuterTestReportSpec.swift
+++ b/Tests/TestReporting/MuterTestReportSpec.swift
@@ -1,6 +1,7 @@
 import Quick
 import Nimble
 import TestingExtensions
+import Foundation
 @testable import muterCore
 
 class MuterTestReportSpec: QuickSpec {

--- a/Tests/TestReporting/ReporterSpec.swift
+++ b/Tests/TestReporting/ReporterSpec.swift
@@ -9,8 +9,10 @@ class ReporterSpec: QuickSpec {
 
         let outcomes = [
             MutationTestOutcome(testSuiteOutcome: .passed,
-                                mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/file3.swift", position: .firstPosition),
-                                operatorDescription: "changed from != to ==")
+                                mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/project/file3.swift", position: .firstPosition),
+                                operatorDescription: "changed from != to ==",
+                                originalProjectDirectoryUrl: URL(string: "/user/project")!
+                                )
         ]
 
         describe("text reporter") {
@@ -22,15 +24,17 @@ class ReporterSpec: QuickSpec {
         describe("xcode reporter") {
             it("returns the report in xcode format") {
                 let outcomes = outcomes + [MutationTestOutcome(testSuiteOutcome: .failed,
-                                                               mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/file4.swift", position: .firstPosition),
-                                                               operatorDescription: "changed from == to !="),
+                                                               mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/project/file4.swift", position: .firstPosition),
+                                                               operatorDescription: "changed from == to !=",
+                                                               originalProjectDirectoryUrl: URL(string: "/user/project")!),
                                            MutationTestOutcome(testSuiteOutcome: .passed,
-                                                               mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/file5.swift", position: .firstPosition),
-                                                               operatorDescription: "changed from == to !=")]
+                                                               mutationPoint: MutationPoint(mutationOperatorId: .negateConditionals, filePath: "/tmp/project/file5.swift", position: .firstPosition),
+                                                               operatorDescription: "changed from == to !=",
+                                                               originalProjectDirectoryUrl: URL(string: "/user/project")!)]
                 
                 expect(Reporter.xcode.generateReport(from: outcomes)) == """
-                /tmp/file3.swift:0:0: warning: Your test suite did not kill this mutant: changed from != to ==
-                /tmp/file5.swift:0:0: warning: Your test suite did not kill this mutant: changed from == to !=
+                /user/project/file3.swift:0:0: warning: Your test suite did not kill this mutant: changed from != to ==
+                /user/project/file5.swift:0:0: warning: Your test suite did not kill this mutant: changed from == to !=
                 """
             }
         }


### PR DESCRIPTION
[closes #138]

 - Add acceptance test that counts the number of temporary paths in the xcode-formatted output
 - Add unit test that proves the xcode reporter doesn't use temporary paths anymore
 - Add unit test that proves MutationTestOutcome can map from a temporary path to the original path of a source file from a user's project